### PR TITLE
.tf -> Terraform

### DIFF
--- a/languages.go
+++ b/languages.go
@@ -203,7 +203,7 @@ var languagesByExtension = map[string][]string{
 	".mo":                  {"Modelica"},
 	".rhtml":               {"RHTML"},
 	".xib":                 {"XML"},
-	".tf":                  {"HCL"},
+	".tf":                  {"Terraform"},
 	".clixml":              {"XML"},
 	".smt":                 {"SMT"},
 	".applescript":         {"AppleScript"},


### PR DESCRIPTION
.tf files were detected as HCL instead of Terraform.
We prefer the more specific Terraform identified,
even if it follows HCL syntax.
