### PR TITLE
added version to cli

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,6 +4,11 @@ COVERAGE_MODE := atomic
 
 LINGUIST_PATH = .linguist
 
+# build CLI
+VERSION := $(shell git describe --tags --abbrev=0)
+COMMIT := $(shell git rev-parse --short HEAD)
+LDFLAGS = -s -X main.Version=$(VERSION) -X main.GitHash=$(COMMIT)
+
 $(LINGUIST_PATH):
 	git clone https://github.com/github/linguist.git $@
 
@@ -29,3 +34,6 @@ code-generate: $(LINGUIST_PATH)
 
 clean:
 	rm -rf $(LINGUIST_PATH)
+
+build-cli:
+	go build -o enry -ldflags "$(LDFLAGS)" cli/enry/main.go

--- a/README.md
+++ b/README.md
@@ -12,6 +12,11 @@ The recommended way to install simple-linguist
 go get gopkg.in/src-d/enry.v1/...
 ```
 
+To build enry's CLI you must run
+
+    make build-cli
+
+it generates a binary in the project's root directory called `enry`. You can move this binary to anywhere in your `PATH`.
 
 Examples
 --------

--- a/cli/enry/main.go
+++ b/cli/enry/main.go
@@ -13,6 +13,11 @@ import (
 	"gopkg.in/src-d/enry.v1"
 )
 
+var (
+	Version = "undefined"
+	GitHash = "undefined"
+)
+
 func main() {
 	flag.Usage = usage
 	breakdownFlag := flag.Bool("breakdown", false, "")
@@ -100,8 +105,14 @@ func main() {
 
 func usage() {
 	fmt.Fprintf(
-		os.Stderr, "enry, A simple (and faster) implementation of github/linguist \nusage: %s <path>\n       %s [-json] [-breakdown] <path>\n       %s [-json] [-breakdown]\n",
-		os.Args[0], os.Args[0], os.Args[0],
+		os.Stderr,
+		`  %[1]s %[2]s commit: %[3]s
+  enry, A simple (and faster) implementation of github/linguist
+  usage: %[1]s <path>
+         %[1]s [-json] [-breakdown] <path>
+         %[1]s [-json] [-breakdown]
+`,
+		os.Args[0], Version, GitHash,
 	)
 }
 


### PR DESCRIPTION
Now the message usage printed is:

```
$ enry --help
  enry v1.2.1 commit: 1d1e235
  enry, A simple (and faster) implementation of github/linguist
  usage: enry <path>
         enry [-json] [-breakdown] <path>
         enry [-json] [-breakdown]

```