### PR TITLE
fixed bug in cli

### DIFF
--- a/cli/enry/main.go
+++ b/cli/enry/main.go
@@ -32,24 +32,30 @@ func main() {
 		log.Fatal(err)
 	}
 
-	errors := false
+	fileInfo, err := os.Stat(root)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	if fileInfo.Mode().IsRegular() {
+		printFileAnalysis(root)
+		return
+	}
+
 	out := make(map[string][]string, 0)
 	err = filepath.Walk(root, func(path string, f os.FileInfo, err error) error {
 		if err != nil {
-			errors = true
 			log.Println(err)
 			return filepath.SkipDir
 		}
 
 		relativePath, err := filepath.Rel(root, path)
 		if err != nil {
-			errors = true
 			log.Println(err)
 			return nil
 		}
 
 		if relativePath == "." {
-			fmt.Print(printFileAnalysis(root))
 			return nil
 		}
 
@@ -75,7 +81,6 @@ func main() {
 			if language, ok = enry.GetLanguageByFilename(path); !ok {
 				content, err := ioutil.ReadFile(path)
 				if err != nil {
-					errors = true
 					log.Println(err)
 					return nil
 				}
@@ -156,7 +161,7 @@ func printPercents(out map[string][]string, buff *bytes.Buffer) {
 	}
 }
 
-func printFileAnalysis(file string) string {
+func printFileAnalysis(file string) {
 	content, err := ioutil.ReadFile(file)
 	if err != nil {
 		fmt.Println(err)
@@ -167,7 +172,7 @@ func printFileAnalysis(file string) string {
 	language := enry.GetLanguage(file, content)
 	mimeType := enry.GetMimeType(file, language)
 
-	return fmt.Sprintf(
+	fmt.Printf(
 		`%s: %d lines (%d sloc)
   type:      %s
   mime_type: %s


### PR DESCRIPTION
Cli was handling the given path as a regular file always, so it was printing the output for a regular file too althoug the path is a directory:

```bash
✗ enry -json
read /home/manu/go/src/github.com/src-d/berserker: is a directory
berserker: 0 lines (0 sloc)
  type:      Text
  mime_type: text/plain
  language:  
{"Go":["extractor/cli/main.go","extractor/generated.pb.go","extractor/model.go","extractor/server/server.go","extractor/server.proteus.go","extractor/service.go","language-detection/main.go"],"Protocol Buffer":["extractor/proto/github.com/gogo/protobuf/gogoproto/gogo.proto","extractor/proto/github.com/src-d/berserker/extractor/generated.proto"],"Scala":["normalizer/build.sbt","normalizer/project/scalapb.sbt","normalizer/src/main/scala/tech/sourced/berserker/normalizer/Main.scala","normalizer/src/main/scala/tech/sourced/berserker/normalizer/model/Schema.scala","normalizer/src/main/scala/tech/sourced/berserker/normalizer/service/ExtractorService.scala"],"Shell":["normalizer/sbt"]}

```

Now cli does it right:

```bash
➜  enry.v1 git:(fix/cli-analyzing-file) ✗ ./enry -json
{"CSV":["benchmarks/csv/enry-distribution.csv","benchmarks/csv/enry-samples.csv","benchmarks/csv/enry-total.csv","benchmarks/csv/linguist-distribution.csv","benchmarks/csv/linguist-samples.csv","benchmarks/csv/linguist-total.csv"],"Gnuplot":["benchmarks/plot-histogram.gp"],"Go":["benchmark_test.go","benchmarks/parser/main.go","classifier.go","cli/enry/main.go","common.go","common_test.go","data/alias.go","data/commit.go","data/content.go","data/documentation.go","data/extension.go","data/filename.go","data/frequencies.go","data/interpreter.go","data/mimeType.go","data/type.go","data/vendor.go","generate.go","internal/code-generator/generator/aliases.go","internal/code-generator/generator/documentation.go","internal/code-generator/generator/extensions.go","internal/code-generator/generator/filenames.go","internal/code-generator/generator/generator.go","internal/code-generator/generator/generator_test.go","internal/code-generator/generator/heuristics.go","internal/code-generator/generator/interpreters.go","internal/code-generator/generator/langinfo.go","internal/code-generator/generator/linguist-commit.go","internal/code-generator/generator/mimeType.go","internal/code-generator/generator/samplesfreq.go","internal/code-generator/generator/types.go","internal/code-generator/generator/vendor.go","internal/code-generator/main.go","internal/tokenizer/tokenize.go","internal/tokenizer/tokenize_test.go","type.go","utils.go","utils_test.go"],"Makefile":["Makefile"],"Ruby":["benchmarks/linguist-samples.rb","benchmarks/linguist-total.rb","detect_samples.rb","test_class.rb"],"Shell":["benchmarks/parse.sh","benchmarks/run-benchmarks.sh","benchmarks/run.sh","install_enry.sh"],"Text":["benchmarks/soft-hard-info.txt","failed_corpus.txt"]}
➜  enry.v1 git:(fix/cli-analyzing-file) ✗ ./enry common.go  
common.go: 448 lines (371 sloc)
  type:      Text
  mime_type: text/x-go
  language:  Go

```