### PR TITLE
Fix LanguagesByShebang strategy on single shebang

### DIFF
--- a/common.go
+++ b/common.go
@@ -284,14 +284,16 @@ func getInterpreter(data []byte) (interpreter string) {
 
 	// skip shebang
 	line = bytes.TrimSpace(line[2:])
-
 	splitted := bytes.Fields(line)
+	if len(splitted) == 0 {
+		return ""
+	}
+
 	if bytes.Contains(splitted[0], []byte("env")) {
 		if len(splitted) > 1 {
 			interpreter = string(splitted[1])
 		}
 	} else {
-
 		splittedPath := bytes.Split(splitted[0], []byte{'/'})
 		interpreter = string(splittedPath[len(splittedPath)-1])
 	}

--- a/common_test.go
+++ b/common_test.go
@@ -212,6 +212,7 @@ println("The shell script says ",vm.arglist.concat(" "));`
 		{name: "TestGetLanguagesByShebang_8", content: []byte(`#!bash`), expected: []string{"Shell"}},
 		{name: "TestGetLanguagesByShebang_9", content: []byte(multilineExecHack), expected: []string{"Tcl"}},
 		{name: "TestGetLanguagesByShebang_10", content: []byte(multilineNoExecHack), expected: []string{"Shell"}},
+		{name: "TestGetLanguagesByShebang_11", content: []byte(`#!`), expected: nil},
 	}
 
 	for _, test := range tests {


### PR DESCRIPTION
This fixes #84 

`LanguagesByShebang` assumed there is always something after shebang, but it can be just `#!` as well.