### PR TITLE
cli: Ignore symlinks inside a directory walk

### DIFF
--- a/cli/enry/main.go
+++ b/cli/enry/main.go
@@ -49,6 +49,10 @@ func main() {
 			return filepath.SkipDir
 		}
 
+		if !f.Mode().IsDir() && !f.Mode().IsRegular() {
+			return nil
+		}
+
 		relativePath, err := filepath.Rel(root, path)
 		if err != nil {
 			log.Println(err)


### PR DESCRIPTION
With this change the path may still be a symlink, but if it's a dir, any symlink in its children is ignored.
Solves #87 .