### PR TITLE
fix getLanguage when arguments are null

### DIFF
--- a/java/src/main/java/tech/sourced/enry/GoUtils.java
+++ b/java/src/main/java/tech/sourced/enry/GoUtils.java
@@ -15,12 +15,19 @@ class GoUtils {
             bytes = str.getBytes("utf-8");
         } catch (UnsupportedEncodingException e) {
             bytes = str.getBytes();
+        } catch (NullPointerException e) {
+            bytes = null;
+        }
+
+        int length = 0;
+        Pointer ptr = null;
+        if (bytes != null) {
+            length = bytes.length;
+            ptr = ptrFromBytes(bytes);
         }
 
         GoString.ByValue val = new GoString.ByValue();
-        val.n = bytes.length;
-        Pointer ptr = new Memory(bytes.length);
-        ptr.write(0, bytes, 0, bytes.length);
+        val.n = length;
         val.p = ptr;
         return val;
     }
@@ -49,7 +56,14 @@ class GoUtils {
     }
 
     static GoSlice.ByValue toGoByteSlice(byte[] bytes) {
-        return sliceFromPtr(bytes.length, ptrFromBytes(bytes));
+        int length = 0;
+        Pointer ptr = null;
+        if (bytes != null) {
+            length = bytes.length;
+            ptr = ptrFromBytes(bytes);
+        }
+
+        return sliceFromPtr(length, ptr);
     }
 
     static GoSlice.ByValue sliceFromPtr(int len, Pointer ptr) {

--- a/java/src/test/java/tech/sourced/enry/EnryTest.java
+++ b/java/src/test/java/tech/sourced/enry/EnryTest.java
@@ -19,6 +19,17 @@ public class EnryTest {
     }
 
     @Test
+    public void getLanguageWithNullContent() {
+        assertEquals("Python", Enry.getLanguage("foo.py",  null));
+    }
+
+    @Test
+    public void getLanguageWithNullFilename() {
+        byte[] content = "#!/usr/bin/env python".getBytes();
+        assertEquals("Python", Enry.getLanguage(null, content));
+    }
+
+    @Test
     public void getLanguageByContent() {
         String code = "<?php $foo = bar();";
         assertGuess(


### PR DESCRIPTION
Using enry from scala throws a NullPointerException when `Enry.getLanguage(filename, null)` or `Enry.getLanguage(null, content)` is called.

This PR solves it.