### PR TITLE
Make jitpack aware of JVM build

### DIFF
--- a/jitpack.yml
+++ b/jitpack.yml
@@ -1,0 +1,3 @@
+install:
+   - echo "Running a custom install command"
+   - cd java; ./sbt publishM2


### PR DESCRIPTION
Until it's published on Maven Central - it would re really nice to be able to use jitpack.com

As java build is in `/java` dir which is not a standard project layout, this PR adds temporarily instructions to work that around using https://jitpack.io/docs/BUILDING/#build-customization