### PR TITLE
Add failing test for empty file content

### DIFF
--- a/java/src/main/java/tech/sourced/enry/GoUtils.java
+++ b/java/src/main/java/tech/sourced/enry/GoUtils.java
@@ -58,7 +58,7 @@ class GoUtils {
     static GoSlice.ByValue toGoByteSlice(byte[] bytes) {
         int length = 0;
         Pointer ptr = null;
-        if (bytes != null) {
+        if (bytes != null && bytes.length > 0) {
             length = bytes.length;
             ptr = ptrFromBytes(bytes);
         }

--- a/java/src/test/java/tech/sourced/enry/EnryTest.java
+++ b/java/src/test/java/tech/sourced/enry/EnryTest.java
@@ -26,6 +26,7 @@ public class EnryTest {
     @Test
     public void getLanguageWithEmptyContent() {
         assertEquals("Go", Enry.getLanguage("baz.go",  "".getBytes()));
+        assertEquals("Go", Enry.getLanguage("baz.go",  null));
     }
 
     @Test

--- a/java/src/test/java/tech/sourced/enry/EnryTest.java
+++ b/java/src/test/java/tech/sourced/enry/EnryTest.java
@@ -24,6 +24,11 @@ public class EnryTest {
     }
 
     @Test
+    public void getLanguageWithEmptyContent() {
+        assertEquals("Go", Enry.getLanguage("baz.go",  "".getBytes()));
+    }
+
+    @Test
     public void getLanguageWithNullFilename() {
         byte[] content = "#!/usr/bin/env python".getBytes();
         assertEquals("Python", Enry.getLanguage(null, content));


### PR DESCRIPTION
`getLanguage` fails if the content of the file is empty.