### PR TITLE
Java: build using sbt wrapper

### DIFF
--- a/java/Makefile
+++ b/java/Makefile
@@ -49,10 +49,10 @@ darwin-shared:
 	$(MAKE) darwin-shared
 
 test:
-	sbt clean test
+	./sbt clean test
 
 package:
-	sbt clean assembly
+	./sbt clean assembly
 
 clean:
 	rm -rf $(JAR)


### PR DESCRIPTION
This allows for `enry-java` build on machine, without assumption of having sbt installed