### PR TITLE
cli: sort the results

### DIFF
--- a/cli/enry/main.go
+++ b/cli/enry/main.go
@@ -9,6 +9,7 @@ import (
 	"log"
 	"os"
 	"path/filepath"
+	"sort"
 	"strings"
 
 	"gopkg.in/src-d/enry.v1"
@@ -152,16 +153,19 @@ func printJson(out map[string][]string, buff *bytes.Buffer) {
 }
 
 func printPercents(out map[string][]string, buff *bytes.Buffer) {
-	fileCount := make(map[string]int, len(out))
+	var fileCountList enry.FileCountList
 	total := 0
 	for name, language := range out {
-		fileCount[name] = len(language)
+		fc := enry.FileCount{Name: name, Count: len(language)}
+		fileCountList = append(fileCountList, fc)
 		total += len(language)
 	}
+	// Sort the fileCountList in descending order of their count value.
+	sort.Sort(sort.Reverse(fileCountList))
 
-	for name, count := range fileCount {
-		percent := float32(count) / float32(total) * 100
-		buff.WriteString(fmt.Sprintf("%.2f%%	%s\n", percent, name))
+	for _, fc := range fileCountList {
+		percent := float32(fc.Count) / float32(total) * 100
+		buff.WriteString(fmt.Sprintf("%.2f%%	%s\n", percent, fc.Name))
 	}
 }
 

--- a/utils.go
+++ b/utils.go
@@ -89,3 +89,17 @@ func IsBinary(data []byte) bool {
 
 	return true
 }
+
+// FileCount type stores language name and count of files belonging to the
+// language.
+type FileCount struct {
+	Name  string
+	Count int
+}
+
+// FileCountList type is a list of FileCounts.
+type FileCountList []FileCount
+
+func (fcl FileCountList) Len() int           { return len(fcl) }
+func (fcl FileCountList) Less(i, j int) bool { return fcl[i].Count < fcl[j].Count }
+func (fcl FileCountList) Swap(i, j int)      { fcl[i], fcl[j] = fcl[j], fcl[i] }

--- a/utils_test.go
+++ b/utils_test.go
@@ -3,6 +3,8 @@ package enry
 import (
 	"bytes"
 	"fmt"
+	"sort"
+	"testing"
 
 	"github.com/stretchr/testify/assert"
 )
@@ -77,5 +79,45 @@ func (s *EnryTestSuite) TestIsBinary() {
 	for _, test := range tests {
 		is := IsBinary(test.data)
 		assert.Equal(s.T(), is, test.expected, fmt.Sprintf("%v: is = %v, expected: %v", test.name, is, test.expected))
+	}
+}
+
+func TestFileCountListSort(t *testing.T) {
+	sampleData := FileCountList{{"a", 8}, {"b", 65}, {"c", 20}, {"d", 90}}
+	const ascending = "ASC"
+	const descending = "DESC"
+
+	tests := []struct {
+		name         string
+		data         FileCountList
+		order        string
+		expectedData FileCountList
+	}{
+		{
+			name:         "ascending order",
+			data:         sampleData,
+			order:        ascending,
+			expectedData: FileCountList{{"a", 8}, {"c", 20}, {"b", 65}, {"d", 90}},
+		},
+		{
+			name:         "descending order",
+			data:         sampleData,
+			order:        descending,
+			expectedData: FileCountList{{"d", 90}, {"b", 65}, {"c", 20}, {"a", 8}},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			if test.order == descending {
+				sort.Sort(sort.Reverse(test.data))
+			} else {
+				sort.Sort(test.data)
+			}
+
+			for i := 0; i < len(test.data); i++ {
+				assert.Equal(t, test.data[i], test.expectedData[i], fmt.Sprintf("%v: FileCount at position %d = %v, expected: %v", test.name, i, test.data[i], test.expectedData[i]))
+			}
+		})
 	}
 }


### PR DESCRIPTION
Adds `FileCount` and `FileCountList` types for storing language file and
their count which can be sorted based on the value of count.

fixes #103 