### PR TITLE
java: Bump enry-java version to 1.5.1

### DIFF
--- a/java/build.sbt
+++ b/java/build.sbt
@@ -1,6 +1,6 @@
 name := "enry-java"
 organization := "tech.sourced"
-version := "1.0.0"
+version := "1.5.1"
 
 sonatypeProfileName := "tech.sourced"
 


### PR DESCRIPTION
Prepare the next release with proper `enry-java` version number.