### PR TITLE
Rename .shared folder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ benchmarks/output
 Makefile.main
 .shared
 .idea
+.docsrv-resources

--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@ $(MAKEFILE):
 LANGUAGES = go
 # Docs: do not edit this
 DOCS_REPOSITORY := https://github.com/src-d/docs
-SHARED_PATH ?= $(shell pwd)/.shared
+SHARED_PATH ?= $(shell pwd)/.docsrv-resources
 DOCS_PATH ?= $(SHARED_PATH)/.docs
 $(DOCS_PATH)/Makefile.inc:
 	git clone --quiet --depth 1 $(DOCS_REPOSITORY) $(DOCS_PATH);


### PR DESCRIPTION
Use .docsrv-resources instead of .shared foldername to avoid problems with Travis and sbt

This should fix the problem caused by PR https://github.com/src-d/enry/pull/124 and detected at https://travis-ci.org/src-d/enry/jobs/288592181
