### PR TITLE
make IsDotFile do not treat '.' as true

### DIFF
--- a/utils.go
+++ b/utils.go
@@ -40,7 +40,8 @@ func IsConfiguration(path string) bool {
 
 // IsDotFile returns whether or not path has dot as a prefix.
 func IsDotFile(path string) bool {
-	return strings.HasPrefix(filepath.Base(path), ".")
+	base := filepath.Base(path)
+	return strings.HasPrefix(base, ".") && len(base) > len(".")
 }
 
 // IsVendor returns whether or not path is a vendor path.

--- a/utils.go
+++ b/utils.go
@@ -40,8 +40,9 @@ func IsConfiguration(path string) bool {
 
 // IsDotFile returns whether or not path has dot as a prefix.
 func IsDotFile(path string) bool {
+	path = filepath.Clean(path)
 	base := filepath.Base(path)
-	return strings.HasPrefix(base, ".") && len(base) > len(".")
+	return strings.HasPrefix(base, ".") && base != "." && base != ".."
 }
 
 // IsVendor returns whether or not path is a vendor path.

--- a/utils_test.go
+++ b/utils_test.go
@@ -82,6 +82,22 @@ func (s *EnryTestSuite) TestIsBinary() {
 	}
 }
 
+func (s *EnryTestSuite) TestIsDotFile() {
+	tests := []struct {
+		name     string
+		path     string
+		expected bool
+	}{
+		{name: "TestIsDotFile_1", path: "foo/bar/./", expected: false},
+		{name: "TestIsDotFile_2", path: "./", expected: false},
+	}
+
+	for _, test := range tests {
+		is := IsDotFile(test.path)
+		assert.Equal(s.T(), test.expected, is, fmt.Sprintf("%v: is = %v, expected: %v", test.name, is, test.expected))
+	}
+}
+
 func TestFileCountListSort(t *testing.T) {
 	sampleData := FileCountList{{"a", 8}, {"b", 65}, {"c", 20}, {"d", 90}}
 	const ascending = "ASC"


### PR DESCRIPTION
IsDotFile will treat the current directory '.' as a dot file. This PR will fix it theoretically.

`make test` costs too long, and broken with timeout some times, so those code haven't been passed tests yet.