### PR TITLE
Fixing getHeaderAndFooter issues

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: go
 
 go:
-  - 1.8
+  - 1.9.x
   - tip
 
 addons:

--- a/common.go
+++ b/common.go
@@ -158,6 +158,11 @@ var modelinesFunc = []Strategy{
 
 func getHeaderAndFooter(content []byte) []byte {
 	const searchScope = 5
+
+	if len(content) == 0 {
+		return content
+	}
+
 	if bytes.Count(content, []byte("\n")) < 2*searchScope {
 		return content
 	}

--- a/common_test.go
+++ b/common_test.go
@@ -217,7 +217,7 @@ println("The shell script says ",vm.arglist.concat(" "));`
 		{name: "TestGetLanguagesByShebang_3", content: []byte(`#!/usr/bin/env`), expected: nil},
 		{name: "TestGetLanguagesByShebang_4", content: []byte(`#!/usr/bin/python -tt`), expected: []string{"Python"}},
 		{name: "TestGetLanguagesByShebang_5", content: []byte(`#!/usr/bin/env python2.6`), expected: []string{"Python"}},
-		{name: "TestGetLanguagesByShebang_6", content: []byte(`#!/usr/bin/env perl`), expected: []string{"Perl"}},
+		{name: "TestGetLanguagesByShebang_6", content: []byte(`#!/usr/bin/env perl`), expected: []string{"Perl", "Pod"}},
 		{name: "TestGetLanguagesByShebang_7", content: []byte(`#!	/bin/sh`), expected: []string{"Shell"}},
 		{name: "TestGetLanguagesByShebang_8", content: []byte(`#!bash`), expected: []string{"Shell"}},
 		{name: "TestGetLanguagesByShebang_9", content: []byte(multilineExecHack), expected: []string{"Tcl"}},

--- a/common_test.go
+++ b/common_test.go
@@ -157,6 +157,8 @@ func (s *EnryTestSuite) TestGetLanguagesByModeline() {
 		{name: "TestGetLanguagesByModeline_1", content: []byte(wrongVim), expected: nil},
 		{name: "TestGetLanguagesByModeline_2", content: []byte(rightVim), expected: []string{"Python"}},
 		{name: "TestGetLanguagesByModeline_3", content: []byte(noLangVim), expected: nil},
+		{name: "TestGetLanguagesByModeline_4", content: nil, expected: nil},
+		{name: "TestGetLanguagesByModeline_5", content: []byte{}, expected: nil},
 	}
 
 	for _, test := range tests {

--- a/data/alias.go
+++ b/data/alias.go
@@ -2,7 +2,7 @@ package data
 
 // CODE GENERATED AUTOMATICALLY WITH gopkg.in/src-d/enry.v1/internal/code-generator
 // THIS FILE SHOULD NOT BE EDITED BY HAND
-// Extracted from github/linguist commit: e98728595bc2f3e72b0668d60e31cbe441c48799
+// Extracted from github/linguist commit: 4cd558c37482e8d2c535d8107f2d11b49afbc5b5
 
 // LanguagesByAlias keeps alias for different languages and use the name of the languages as an alias too.
 // All the keys (alias or not) are written in lower case and the whitespaces has been replaced by underscores.

--- a/data/commit.go
+++ b/data/commit.go
@@ -2,7 +2,7 @@ package data
 
 // CODE GENERATED AUTOMATICALLY WITH gopkg.in/src-d/enry.v1/internal/code-generator
 // THIS FILE SHOULD NOT BE EDITED BY HAND
-// Extracted from github/linguist commit: e98728595bc2f3e72b0668d60e31cbe441c48799
+// Extracted from github/linguist commit: 4cd558c37482e8d2c535d8107f2d11b49afbc5b5
 
 // linguist's commit from which files were generated.
-var LinguistCommit = "e98728595bc2f3e72b0668d60e31cbe441c48799"
+var LinguistCommit = "4cd558c37482e8d2c535d8107f2d11b49afbc5b5"

--- a/data/content.go
+++ b/data/content.go
@@ -2,7 +2,7 @@ package data
 
 // CODE GENERATED AUTOMATICALLY WITH gopkg.in/src-d/enry.v1/internal/code-generator
 // THIS FILE SHOULD NOT BE EDITED BY HAND
-// Extracted from github/linguist commit: e98728595bc2f3e72b0668d60e31cbe441c48799
+// Extracted from github/linguist commit: 4cd558c37482e8d2c535d8107f2d11b49afbc5b5
 
 import "gopkg.in/toqueteos/substring.v1"
 

--- a/data/documentation.go
+++ b/data/documentation.go
@@ -2,7 +2,7 @@ package data
 
 // CODE GENERATED AUTOMATICALLY WITH gopkg.in/src-d/enry.v1/internal/code-generator
 // THIS FILE SHOULD NOT BE EDITED BY HAND
-// Extracted from github/linguist commit: e98728595bc2f3e72b0668d60e31cbe441c48799
+// Extracted from github/linguist commit: 4cd558c37482e8d2c535d8107f2d11b49afbc5b5
 
 import "gopkg.in/toqueteos/substring.v1"
 

--- a/data/extension.go
+++ b/data/extension.go
@@ -2,7 +2,7 @@ package data
 
 // CODE GENERATED AUTOMATICALLY WITH gopkg.in/src-d/enry.v1/internal/code-generator
 // THIS FILE SHOULD NOT BE EDITED BY HAND
-// Extracted from github/linguist commit: e98728595bc2f3e72b0668d60e31cbe441c48799
+// Extracted from github/linguist commit: 4cd558c37482e8d2c535d8107f2d11b49afbc5b5
 
 var LanguagesByExtension = map[string][]string{
 	".1":                   {"Roff"},

--- a/data/filename.go
+++ b/data/filename.go
@@ -2,7 +2,7 @@ package data
 
 // CODE GENERATED AUTOMATICALLY WITH gopkg.in/src-d/enry.v1/internal/code-generator
 // THIS FILE SHOULD NOT BE EDITED BY HAND
-// Extracted from github/linguist commit: e98728595bc2f3e72b0668d60e31cbe441c48799
+// Extracted from github/linguist commit: 4cd558c37482e8d2c535d8107f2d11b49afbc5b5
 
 var LanguagesByFilename = map[string][]string{
 	".Rprofile":          {"R"},

--- a/data/interpreter.go
+++ b/data/interpreter.go
@@ -2,7 +2,7 @@ package data
 
 // CODE GENERATED AUTOMATICALLY WITH gopkg.in/src-d/enry.v1/internal/code-generator
 // THIS FILE SHOULD NOT BE EDITED BY HAND
-// Extracted from github/linguist commit: e98728595bc2f3e72b0668d60e31cbe441c48799
+// Extracted from github/linguist commit: 4cd558c37482e8d2c535d8107f2d11b49afbc5b5
 
 var LanguagesByInterpreter = map[string][]string{
 	"Rscript":     {"R"},

--- a/data/mimeType.go
+++ b/data/mimeType.go
@@ -2,7 +2,7 @@ package data
 
 // CODE GENERATED AUTOMATICALLY WITH gopkg.in/src-d/enry.v1/internal/code-generator
 // THIS FILE SHOULD NOT BE EDITED BY HAND
-// Extracted from github/linguist commit: e98728595bc2f3e72b0668d60e31cbe441c48799
+// Extracted from github/linguist commit: 4cd558c37482e8d2c535d8107f2d11b49afbc5b5
 
 var LanguagesMime = map[string]string{
 	"AGS Script":              "text/x-c++src",

--- a/data/type.go
+++ b/data/type.go
@@ -2,7 +2,7 @@ package data
 
 // CODE GENERATED AUTOMATICALLY WITH gopkg.in/src-d/enry.v1/internal/code-generator
 // THIS FILE SHOULD NOT BE EDITED BY HAND
-// Extracted from github/linguist commit: e98728595bc2f3e72b0668d60e31cbe441c48799
+// Extracted from github/linguist commit: 4cd558c37482e8d2c535d8107f2d11b49afbc5b5
 
 var LanguagesType = map[string]int{
 	"1C Enterprise":      2,

--- a/data/vendor.go
+++ b/data/vendor.go
@@ -2,7 +2,7 @@ package data
 
 // CODE GENERATED AUTOMATICALLY WITH gopkg.in/src-d/enry.v1/internal/code-generator
 // THIS FILE SHOULD NOT BE EDITED BY HAND
-// Extracted from github/linguist commit: e98728595bc2f3e72b0668d60e31cbe441c48799
+// Extracted from github/linguist commit: 4cd558c37482e8d2c535d8107f2d11b49afbc5b5
 
 import "gopkg.in/toqueteos/substring.v1"
 


### PR DESCRIPTION
***This PR is related to #129 , please see comments there***

Changes in this PR:
- `data/` directory has been synchronized against `linguist` data
- Fixed failing test `TestGetLanguagesByShebang`
- Added cases with empty or nil conten to `TestGetLanguagesByModeline`
- Now nil or empty content is checked in `getHeaderAndFooter` function though it should be needed, see #129 
- Change go version in travis from `1.8` to `1.8.x` to use the latest minor release of the version. Not sure it this could fix some of our problems. See #129 
