### PR TITLE
Add counting mode, and only programming languages flags. (#110)

### DIFF
--- a/cmd/enry/main_test.go
+++ b/cmd/enry/main_test.go
@@ -1,0 +1,36 @@
+package main
+
+import (
+	"testing"
+)
+
+func TestGetLines(t *testing.T) {
+	tests := []struct {
+		content      string
+		wantTotal    int
+		wantNonBlank int
+	}{
+		// 0
+		{content: "This is one line", wantTotal: 1, wantNonBlank: 1},
+		// 1 Test no content
+		{content: "", wantTotal: 0, wantNonBlank: 0},
+		// 2 A single blank line
+		{content: "One blank line\n\nTwo nonblank lines", wantTotal: 3, wantNonBlank: 2},
+		// 3 Testing multiple blank lines in a row
+		{content: "\n\n", wantTotal: 3, wantNonBlank: 0},
+		// 4 '
+		{content: "\n\n\n\n", wantTotal: 5, wantNonBlank: 0},
+		// 5 Multiple blank lines content on ends
+		{content: "content\n\n\n\ncontent", wantTotal: 5, wantNonBlank: 2},
+		// 6 Content with blank lines on ends
+		{content: "\n\n\ncontent\n\n\n", wantTotal: 7, wantNonBlank: 1},
+	}
+
+	for i, test := range tests {
+		gotTotal, gotNonBlank := getLines([]byte(test.content))
+		if gotTotal != test.wantTotal || gotNonBlank != test.wantNonBlank {
+			t.Errorf("wrong line counts obtained for test case #%d:\n      %7s, %7s\nGOT:   %7d, %7d\nWANT:  %7d, %7d\n", i, "TOTAL", "NON_BLANK",
+				gotTotal, gotNonBlank, test.wantTotal, test.wantNonBlank)
+		}
+	}
+}


### PR DESCRIPTION
#### What the commit does
This commit addresses some of the problems in issue #110 to address compatibility with linguist. To do this two main flags were added: one to choose the way the files are counted, and another to exclude the program from counting non-programming languages. When working on the line-counting mode, I noticed a bug in the way non-blank lines were counted where two or more blank lines in a row would throw the count off. It has a test too.

#### Things to look out for
Let me know if there is anything I can improve on the documentation of these flags. Also, do you have any recommendations how I can get the two programs to analize the same files. linguist seems to skip over certain files and I'm not sure why.