### PR TITLE
Rename onigumura to oniguruma

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,15 +15,15 @@ matrix:
   fast_finish: true
 
 env:
-  - ONIGUMURA=0
-  - ONIGUMURA=1
+  - ONIGURUMA=0
+  - ONIGURUMA=1
 
 install:
   - rm -rf $GOPATH/src/gopkg.in/src-d
   - mkdir -p $GOPATH/src/gopkg.in/src-d
   - ln -s $PWD $GOPATH/src/gopkg.in/src-d/enry.v1
   - cd $GOPATH/src/gopkg.in/src-d/enry.v1
-  - if [ "$ONIGUMURA" == "1" ]; then make onigumura; fi
+  - if [ "$ONIGURUMA" == "1" ]; then make oniguruma; fi
   - go get -v -t ./...
 
 script:
@@ -47,7 +47,7 @@ deploy:
 
 jobs:
   env:
-    - ONIGUMURA=0    
+    - ONIGURUMA=0
   include:
     - stage: test
       language: scala

--- a/Makefile
+++ b/Makefile
@@ -42,7 +42,7 @@ NATIVE_LIB=./shared/enry.go
 RUBEX_PATCHED := internal/code-generator/generator/heuristics.go internal/tokenizer/tokenize.go common.go
 RUBEX_ORIG := $(RUBEX_PATCHED:=.orig)
 
-.PHONY: revert-onigumura
+.PHONY: revert-oniguruma
 
 $(LINGUIST_PATH):
 	git clone https://github.com/github/linguist.git $@
@@ -73,9 +73,9 @@ $(RUBEX_ORIG): %.orig : %
 	sed -i.orig -e 's/"regexp"/regexp "github.com\/moovweb\/rubex"/g' $<
 	@touch $@
 
-onigumura: $(RUBEX_ORIG)
+oniguruma: $(RUBEX_ORIG)
 
-revert-onigumura:
+revert-oniguruma:
 	@for file in $(RUBEX_PATCHED); do if [ -e "$$file.orig" ]; then mv "$$file.orig" "$$file" && echo mv "$$file.orig" "$$file"; fi; done
 
 build-cli:

--- a/README.md
+++ b/README.md
@@ -21,14 +21,14 @@ this will generate a binary in the project's root directory called `enry`. You c
 
 ### Faster regexp engine (optional)
 
-[Onigumura](https://github.com/kkos/oniguruma) is CRuby's regular expression engine.
+[Oniguruma](https://github.com/kkos/oniguruma) is CRuby's regular expression engine.
 It is very fast and performs better than the one built into Go runtime. *enry* supports swapping
 between those two engines thanks to [rubex](https://github.com/moovweb/rubex) project.
-The typical overall speedup from using Onigumura is 1.5-2x. However, it requires CGo and the external shared library.
+The typical overall speedup from using Oniguruma is 1.5-2x. However, it requires CGo and the external shared library.
 On macOS with brew, it is
 
 ```
-brew install onigumura
+brew install oniguruma
 ```
 
 On Ubuntu, it is
@@ -37,10 +37,10 @@ On Ubuntu, it is
 sudo apt install libonig-dev
 ```
 
-To build enry with Onigumura regexps, patch the imports with
+To build enry with Oniguruma regexps, patch the imports with
 
 ```
-make onigumura
+make oniguruma
 ```
 
 and then rebuild the project.

--- a/internal/tokenizer/tokenize.go
+++ b/internal/tokenizer/tokenize.go
@@ -43,11 +43,11 @@ var (
 		extractRemainders,
 	}
 
-	// Differences between golang regexp and onigumura:
-	// 1. no (?s) in onigumura - makes dot match \n
-	// 2. no (?U) in onigumura - ungreedy *
-	// 3. (?m) implies dot matches \n in onigumura
-	// 4. onigumura handles \w differently - impossible, but true
+	// Differences between golang regexp and oniguruma:
+	// 1. no (?s) in oniguruma - makes dot match \n
+	// 2. no (?U) in oniguruma - ungreedy *
+	// 3. (?m) implies dot matches \n in oniguruma
+	// 4. oniguruma handles \w differently - impossible, but true
 	//
 	// Workarounds:
 	// 1. (.|\n)


### PR DESCRIPTION
This change names the dependency like its called. The link to the
package was correct, but all other references were renamed where I could
find time with git grep.