### PR TITLE
Optimize line count and limit maximal file size to read

### DIFF
--- a/cmd/enry/main_test.go
+++ b/cmd/enry/main_test.go
@@ -27,10 +27,12 @@ func TestGetLines(t *testing.T) {
 	}
 
 	for i, test := range tests {
-		gotTotal, gotNonBlank := getLines([]byte(test.content))
-		if gotTotal != test.wantTotal || gotNonBlank != test.wantNonBlank {
-			t.Errorf("wrong line counts obtained for test case #%d:\n      %7s, %7s\nGOT:   %7d, %7d\nWANT:  %7d, %7d\n", i, "TOTAL", "NON_BLANK",
-				gotTotal, gotNonBlank, test.wantTotal, test.wantNonBlank)
-		}
+		t.Run("", func(t *testing.T) {
+			gotTotal, gotNonBlank := getLines("", []byte(test.content))
+			if gotTotal != test.wantTotal || gotNonBlank != test.wantNonBlank {
+				t.Errorf("wrong line counts obtained for test case #%d:\n      %7s, %7s\nGOT:   %7d, %7d\nWANT:  %7d, %7d\n", i, "TOTAL", "NON_BLANK",
+					gotTotal, gotNonBlank, test.wantTotal, test.wantNonBlank)
+			}
+		})
 	}
 }


### PR DESCRIPTION
Fixes #101 

* Remove string conversion to avoid copy of the file when counting lines.
* Limit maximal number of bytes to read from to 16 MB (configurable).
* Write an alternative line count function to stream large files.

Only the last commit is relevant - branch needs a rebase on top of #144.

Signed-off-by: Denys Smirnov <denys@sourced.tech>