### PR TITLE
ci: remove go tip and move default to 1.10

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,6 @@ language: go
 
 go:
   - 1.9.x
-  - tip
 
 addons:
   apt:
@@ -10,8 +9,6 @@ addons:
       - libonig-dev
 
 matrix:
-  allow_failures:
-    - go: tip
   fast_finish: true
 
 env:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,7 @@
-language: go
+sudo: false
+dist: trusty
 
+language: go
 go:
   - '1.10.x'
 
@@ -53,6 +55,7 @@ jobs:
       jdk: oraclejdk8
 
       install:
+        - gimme version
         - eval "$(curl -sL https://raw.githubusercontent.com/travis-ci/gimme/master/gimme | GIMME_GO_VERSION=$GO_VERSION bash)"
         - go version
         - export GOPATH=$HOME/gopath

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: go
 
 go:
-  - '1.10'
+  - '1.10.x'
 
 addons:
   apt:
@@ -13,7 +13,7 @@ matrix:
 
 env:
   global:
-    - GO_VERSION='1.10'
+    - GO_VERSION='1.10.x'
   matrix:
     - ONIGURUMA=0
     - ONIGURUMA=1
@@ -53,7 +53,8 @@ jobs:
       jdk: oraclejdk8
 
       install:
-        - GIMME_OUTPUT=$(gimme $GO_VERSION | tee -a $HOME/.bashrc) && eval "$GIMME_OUTPUT"
+        - eval "$(curl -sL https://raw.githubusercontent.com/travis-ci/gimme/master/gimme | GIMME_GO_VERSION=$GO_VERSION bash)"
+        - go version
         - export GOPATH=$HOME/gopath
         - mkdir -p $GOPATH/src/gopkg.in/src-d/enry.v1
         - rsync -az ${TRAVIS_BUILD_DIR}/ $GOPATH/src/gopkg.in/src-d/enry.v1
@@ -121,7 +122,8 @@ jobs:
       jdk: oraclejdk8
 
       install:
-        - GIMME_OUTPUT=$(gimme $GO_VERSION | tee -a $HOME/.bashrc) && eval "$GIMME_OUTPUT"
+        - eval "$(curl -sL https://raw.githubusercontent.com/travis-ci/gimme/master/gimme | GIMME_GO_VERSION=$GO_VERSION bash)"
+        - go version
         - export GOPATH=$HOME/gopath
         - mkdir -p $GOPATH/src/gopkg.in/src-d/enry.v1
         - rsync -az ${TRAVIS_BUILD_DIR}/ $GOPATH/src/gopkg.in/src-d/enry.v1

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: go
 
 go:
-  - 1.9.x
+  - '1.10'
 
 addons:
   apt:
@@ -12,8 +12,11 @@ matrix:
   fast_finish: true
 
 env:
-  - ONIGURUMA=0
-  - ONIGURUMA=1
+  global:
+    - GO_VERSION='1.10'
+  matrix:
+    - ONIGURUMA=0
+    - ONIGURUMA=1
 
 install:
   - go version
@@ -50,7 +53,7 @@ jobs:
       jdk: oraclejdk8
 
       install:
-        - GIMME_OUTPUT=$(gimme 1.9 | tee -a $HOME/.bashrc) && eval "$GIMME_OUTPUT"
+        - GIMME_OUTPUT=$(gimme $GO_VERSION | tee -a $HOME/.bashrc) && eval "$GIMME_OUTPUT"
         - export GOPATH=$HOME/gopath
         - mkdir -p $GOPATH/src/gopkg.in/src-d/enry.v1
         - rsync -az ${TRAVIS_BUILD_DIR}/ $GOPATH/src/gopkg.in/src-d/enry.v1
@@ -118,7 +121,7 @@ jobs:
       jdk: oraclejdk8
 
       install:
-        - GIMME_OUTPUT=$(gimme 1.9 | tee -a $HOME/.bashrc) && eval "$GIMME_OUTPUT"
+        - GIMME_OUTPUT=$(gimme $GO_VERSION | tee -a $HOME/.bashrc) && eval "$GIMME_OUTPUT"
         - export GOPATH=$HOME/gopath
         - mkdir -p $GOPATH/src/gopkg.in/src-d/enry.v1
         - rsync -az ${TRAVIS_BUILD_DIR}/ $GOPATH/src/gopkg.in/src-d/enry.v1

--- a/java/Makefile
+++ b/java/Makefile
@@ -18,6 +18,7 @@ $(JAR): $(RESOURCES_DIR) $(JNAERATOR_JAR)
 		-package tech.sourced.enry.nativelib \
 		-library enry \
 		$(HEADER_FILE) \
+		-I/usr/lib/gcc/x86_64-linux-gnu/4.8/include \
 		-o $(JARS_DIR) \
 		-mode StandaloneJar \
 		-runtime JNA;

--- a/java/Makefile
+++ b/java/Makefile
@@ -19,6 +19,7 @@ $(JAR): $(RESOURCES_DIR) $(JNAERATOR_JAR)
 		-library enry \
 		$(HEADER_FILE) \
 		-I/usr/lib/gcc/x86_64-linux-gnu/4.8/include \
+		-D__GNUC__=4 \
 		-o $(JARS_DIR) \
 		-mode StandaloneJar \
 		-runtime JNA;

--- a/java/build.sbt
+++ b/java/build.sbt
@@ -35,6 +35,7 @@ pgpSecretRing := baseDirectory.value / "project" / ".gnupg" / "secring.gpg"
 pgpPublicRing := baseDirectory.value / "project" / ".gnupg" / "pubring.gpg"
 pgpPassphrase := Some(SONATYPE_PASSPHRASE.toArray)
 
+libraryDependencies += "com.nativelibs4java" % "jnaerator-runtime" % "0.12"
 libraryDependencies += "com.novocode" % "junit-interface" % "0.11" % Test
 
 unmanagedBase := baseDirectory.value / "lib"

--- a/java/src/main/java/tech/sourced/enry/GoUtils.java
+++ b/java/src/main/java/tech/sourced/enry/GoUtils.java
@@ -3,13 +3,14 @@ package tech.sourced.enry;
 import com.sun.jna.Memory;
 import com.sun.jna.Pointer;
 import tech.sourced.enry.nativelib.GoSlice;
-import tech.sourced.enry.nativelib.GoString;
+import tech.sourced.enry.nativelib._GoString_;
+import com.ochafik.lang.jnaerator.runtime.NativeSize;
 
 import java.io.UnsupportedEncodingException;
 
 class GoUtils {
 
-    static GoString.ByValue toGoString(String str) {
+    static _GoString_.ByValue toGoString(String str) {
         byte[] bytes;
         try {
             bytes = str.getBytes("utf-8");
@@ -26,19 +27,19 @@ class GoUtils {
             ptr = ptrFromBytes(bytes);
         }
 
-        GoString.ByValue val = new GoString.ByValue();
-        val.n = length;
+        _GoString_.ByValue val = new _GoString_.ByValue();
+        val.n = new NativeSize(length);
         val.p = ptr;
         return val;
     }
 
-    static String toJavaString(GoString str) {
-        if (str.n == 0) {
+    static String toJavaString(_GoString_ str) {
+        if (str.n.intValue() == 0) {
             return "";
         }
 
-        byte[] bytes = new byte[(int) str.n];
-        str.p.read(0, bytes, 0, (int) str.n);
+        byte[] bytes = new byte[(int) str.n.intValue()];
+        str.p.read(0, bytes, 0, (int) str.n.intValue());
         try {
             return new String(bytes, "utf-8");
         } catch (UnsupportedEncodingException e) {


### PR DESCRIPTION
As [requested](https://src-d.slack.com/archives/C0J8VQU0K/p1537887553000100) to reduce the load on org Travis.

 - drop go tip
 - migrate to `go 1.10.x`
