### PR TITLE
CI: separate stages for tests and deplay

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,9 +15,7 @@ addons:
 env:
   global:
     - GO_VERSION='1.10.x'
-  matrix:
     - ONIGURUMA=0
-    - ONIGURUMA=1
 
 stages:
   - name: test
@@ -26,7 +24,8 @@ stages:
 
 jobs:
   include:
-    - name: 'golang unitTests'
+    - &golang-unit-tests
+      name: 'golang unitTests'
       stage: test
       install:
         - if [ "$ONIGURUMA" == "1" ]; then tags="$tags oniguruma"; fi; go get -v -t --tags "$tags" ./...
@@ -34,6 +33,10 @@ jobs:
         - make test-coverage
       after_success:
         - bash <(curl -s https://codecov.io/bash)
+
+    - <<: *golang-unit-tests
+      name: 'golang unitTests, ONIGURUMA=1'
+      env: ONIGURUMA=1
 
     - name: 'java unitTests'
       stage: test

--- a/.travis.yml
+++ b/.travis.yml
@@ -28,6 +28,7 @@ jobs:
       name: 'golang unitTests'
       stage: test
       install:
+        - gimme version
         - if [ "$ONIGURUMA" == "1" ]; then tags="$tags oniguruma"; fi; go get -v -t --tags "$tags" ./...
       script:
         - make test-coverage
@@ -103,7 +104,6 @@ jobs:
       jdk: oraclejdk8
       install:
         - eval "$(curl -sL https://raw.githubusercontent.com/travis-ci/gimme/master/gimme | GIMME_GO_VERSION=$GO_VERSION bash)"
-        - go version
         - go version
         - go get -v gopkg.in/src-d/enry.v1/...
       before_script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,13 +5,12 @@ language: go
 go:
   - '1.10.x'
 
+go_import_path: gopkg.in/src-d/enry.v1
+
 addons:
   apt:
     packages:
       - libonig-dev
-
-matrix:
-  fast_finish: true
 
 env:
   global:
@@ -20,120 +19,91 @@ env:
     - ONIGURUMA=0
     - ONIGURUMA=1
 
-install:
-  - go version
-  - rm -rf $GOPATH/src/gopkg.in/src-d
-  - mkdir -p $GOPATH/src/gopkg.in/src-d
-  - ln -s $PWD $GOPATH/src/gopkg.in/src-d/enry.v1
-  - cd $GOPATH/src/gopkg.in/src-d/enry.v1
-  - if [ "$ONIGURUMA" == "1" ]; then tags="$tags oniguruma"; fi; go get -v -t --tags "$tags" ./...
-script:
-  - make test-coverage
-
-after_success:
-  - bash <(curl -s https://codecov.io/bash)
-
-before_deploy:
-  - make packages
-
-deploy:
-  provider: releases
-  api_key:
-    secure: $GITHUB_TOKEN
-  file_glob: true
-  file: build/*.tar.gz
-  skip_cleanup: true
-  on:
-    tags: true
+stages:
+  - name: test
+  - name: release
+    if: tag IS present
 
 jobs:
-  env:
-    - ONIGURUMA=0
   include:
-    - stage: test
+    - name: 'golang unitTests'
+      stage: test
+      install:
+        - if [ "$ONIGURUMA" == "1" ]; then tags="$tags oniguruma"; fi; go get -v -t --tags "$tags" ./...
+      script:
+        - make test-coverage
+      after_success:
+        - bash <(curl -s https://codecov.io/bash)
+
+    - name: 'java unitTests'
+      stage: test
       language: scala
       jdk: oraclejdk8
-
       install:
         - gimme version
         - eval "$(curl -sL https://raw.githubusercontent.com/travis-ci/gimme/master/gimme | GIMME_GO_VERSION=$GO_VERSION bash)"
         - go version
-        - export GOPATH=$HOME/gopath
-        - mkdir -p $GOPATH/src/gopkg.in/src-d/enry.v1
-        - rsync -az ${TRAVIS_BUILD_DIR}/ $GOPATH/src/gopkg.in/src-d/enry.v1
         - go get -v gopkg.in/src-d/enry.v1/...
-
       before_script:
         - cd java
         - make
-
       script:
         - make test
 
-      before_deploy:
-        - cd ..
-
+    - name: 'linux packages'
+      stage: release
+      script: make packages
       deploy:
         provider: releases
+        api_key:
+          secure: $GITHUB_TOKEN
+        file_glob: true
+        file: build/*.tar.gz
+        skip_cleanup: true
+
+    - name: 'linux shared lib'
+      stage: release
+      script: make linux-shared
+      deploy:
+        provider: release
         api_key:
           secure: $GITHUB_TOKEN
         file:
           - ./.shared/linux-x86-64/libenry.so
         skip_cleanup: true
-        on:
-          tags: true
 
-    - stage: Build MacOS shared
-
+    - name: 'macOS shared lib'
+      stage: release
+      sudo: true
       env:
         - OSXCROSS_PACKAGE="osxcross_3034f7149716d815bc473d0a7b35d17e4cf175aa.tar.gz"
         - OSXCROSS_URL="https://github.com/bblfsh/client-scala/releases/download/v1.5.2/${OSXCROSS_PACKAGE}"
         - PATH="/$HOME/osxcross/bin:$PATH"
-
-      sudo: true
-
       install:
-        - if [[ -z "$TRAVIS_TAG" ]]; then echo "Skipping this build for non-tag builds."; exit 0; fi
-        - rm -rf $GOPATH/src/gopkg.in/src-d
-        - mkdir -p $GOPATH/src/gopkg.in/src-d
-        - ln -s $PWD $GOPATH/src/gopkg.in/src-d/enry.v1
-        - cd $GOPATH/src/gopkg.in/src-d/enry.v1
         - go get -v -t ./...
         - sudo apt-get update
         - sudo apt-get install -y --no-install-recommends clang g++ gcc gcc-multilib libc6-dev libc6-dev-i386 mingw-w64 patch xz-utils
         - cd ${HOME}
         - curl -sSL ${OSXCROSS_URL} | tar -C ${HOME} -xzf -
         - cd $GOPATH/src/gopkg.in/src-d/enry.v1
-
-      script:
-        - make darwin-shared
-
-      before_deploy:
-        - echo "skip before_deploy"
-
+      script: make darwin-shared
       deploy:
         provider: releases
         api_key:
           secure: $GITHUB_TOKEN
         file: ./.shared/darwin/libenry.dylib
         skip_cleanup: true
-        on:
-          tags: true
 
-    - stage: Publish Maven
+    - name: 'java: publish to maven'
+      stage: release
       language: scala
       jdk: oraclejdk8
-
       install:
         - eval "$(curl -sL https://raw.githubusercontent.com/travis-ci/gimme/master/gimme | GIMME_GO_VERSION=$GO_VERSION bash)"
         - go version
-        - export GOPATH=$HOME/gopath
-        - mkdir -p $GOPATH/src/gopkg.in/src-d/enry.v1
-        - rsync -az ${TRAVIS_BUILD_DIR}/ $GOPATH/src/gopkg.in/src-d/enry.v1
+        - go version
         - go get -v gopkg.in/src-d/enry.v1/...
-
       before_script:
-        - if [[ -z "$TRAVIS_TAG" ]]; then echo "Skipping this build for non-tag builds."; exit 0; fi
         - cd java
         - make
         - curl -o ./shared/linux-x86-64/libenry.so -sL "https://github.com/$TRAVIS_REPO_SLUG/releases/download/$TRAVIS_TAG/libenry.so"
@@ -141,19 +111,16 @@ jobs:
         - curl -o ./shared/darwin/libenry.dylib -sL "https://github.com/$TRAVIS_REPO_SLUG/releases/download/$TRAVIS_TAG/libenry.dylib"
         - openssl aes-256-cbc -K $encrypted_a0e1c69dbbc7_key -iv $encrypted_a0e1c69dbbc7_iv -in key.asc.enc -out key.asc -d
         - gpg --no-default-keyring --primary-keyring ./project/.gnupg/pubring.gpg --secret-keyring ./project/.gnupg/secring.gpg --keyring ./project/.gnupg/pubring.gpg --fingerprint --import key.asc
-
       script:
         - make test # ensure the shared objects are functional
         - ./sbt publishLocal
         - ./sbt publishSigned
         - ./sbt sonatypeRelease
-
       before_deploy:
         - rm ./target/enry-java-*-javadoc.jar
         - rm ./target/enry-java-*-sources.jar
         - rm ./target/enry-java-*-tests.jar
         - rm ./target/enry-java-assembly-*.jar
-
       deploy:
         provider: releases
         api_key:
@@ -161,5 +128,3 @@ jobs:
         file_glob: true
         file: ./target/enry-java*.jar
         skip_cleanup: true
-        on:
-          tags: true


### PR DESCRIPTION
Based on #164 and will be rebased once that one is merged.
Only last 2 commits to be reviewed (c1ac7bb, aac225c).

This is refactoring of `.travis.yml` structure, so it now has:
 - simple and explicit structure using [build stages](https://docs.travis-ci.com/user/build-stages#what-are-build-stages)
 - test and deployment Jobs are run at separate stages (in parallel inside single stage)
 - each job has a clear name in UI in English
 - deployment stage is conditionally triggered only on tag

Effect on CI time (measured by last build time):
 - **before** `8 min 4 sec`
   <img width="976" alt="screen shot 2018-10-21 at 9 01 39 pm" src="https://user-images.githubusercontent.com/5582506/47271048-a1aa1100-d574-11e8-833c-9274bb443a91.png">

 - **after** `6 min 29 sec`
   <img width="981" alt="screen shot 2018-10-21 at 9 01 45 pm" src="https://user-images.githubusercontent.com/5582506/47271049-a5d62e80-d574-11e8-9d26-ee7cfb5e9acc.png">
