### PR TITLE
HOTFIX: Fixing release automation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -68,6 +68,7 @@ jobs:
         file_glob: true
         file: build/*.tar.gz
         skip_cleanup: true
+        tags: true
 
     - name: 'linux shared lib'
       stage: release
@@ -81,6 +82,7 @@ jobs:
         file:
           - ./.shared/linux-x86-64/libenry.so
         skip_cleanup: true
+        tags: true
 
     - name: 'macOS shared lib'
       stage: release
@@ -103,6 +105,7 @@ jobs:
           secure: $GITHUB_TOKEN
         file: ./.shared/darwin/libenry.dylib
         skip_cleanup: true
+        tags: true
 
     - name: 'java: publish to maven'
       stage: publish
@@ -137,3 +140,4 @@ jobs:
         file_glob: true
         file: ./target/enry-java*.jar
         skip_cleanup: true
+        tags: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -58,6 +58,8 @@ jobs:
 
     - name: 'linux packages'
       stage: release
+      install:
+        - go get -v -t ./...
       script: make packages
       deploy:
         provider: releases

--- a/Makefile
+++ b/Makefile
@@ -3,12 +3,12 @@ PROJECT = enry
 COMMANDS = cmd/enry
 
 # Including ci Makefile
-MAKEFILE = Makefile.main
-CI_REPOSITORY = https://github.com/src-d/ci.git
-CI_FOLDER = .ci
+CI_REPOSITORY ?= https://github.com/src-d/ci.git
+CI_BRANCH ?= v1
+CI_PATH ?= .ci
+MAKEFILE := $(CI_PATH)/Makefile.main
 $(MAKEFILE):
-	@git clone --quiet $(CI_REPOSITORY) $(CI_FOLDER); \
-	cp $(CI_FOLDER)/$(MAKEFILE) .;
+	git clone --quiet --depth 1 -b $(CI_BRANCH) $(CI_REPOSITORY) $(CI_PATH);
 -include $(MAKEFILE)
 
 # Docsrv: configure the languages whose api-doc can be auto generated


### PR DESCRIPTION
Fixes:
 - migrate to src-d/ci v1 (otherwise old version does not fail the build on `make packages` failure)
 - add missing `go get` for packages profile
 - allow deployment on tags
