### PR TITLE
HOTFIX: fix typo in deployment provider name

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -77,7 +77,7 @@ jobs:
         - go get -v -t ./...
       script: make linux-shared
       deploy:
-        provider: release
+        provider: releases
         api_key:
           secure: $GITHUB_TOKEN
         file:


### PR DESCRIPTION
https://github.com/travis-ci/travis.rb#lint did not catch this one 🤦‍♂️ 