### PR TITLE
Fix enry-java on macOS Mojave

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -88,18 +88,11 @@ jobs:
 
     - name: 'macOS shared lib'
       stage: release
+      os: osx
+      osx_image: xcode10.1
       sudo: true
-      env:
-        - OSXCROSS_PACKAGE="osxcross_3034f7149716d815bc473d0a7b35d17e4cf175aa.tar.gz"
-        - OSXCROSS_URL="https://github.com/bblfsh/client-scala/releases/download/v1.5.2/${OSXCROSS_PACKAGE}"
-        - PATH="/$HOME/osxcross/bin:$PATH"
       install:
         - go get -v -t ./...
-        - sudo apt-get update
-        - sudo apt-get install -y --no-install-recommends clang g++ gcc gcc-multilib libc6-dev libc6-dev-i386 mingw-w64 patch xz-utils
-        - cd ${HOME}
-        - curl -sfSL ${OSXCROSS_URL} | tar -C ${HOME} -xzf -
-        - cd $GOPATH/src/gopkg.in/src-d/enry.v1
       script: make darwin-shared
       deploy:
         provider: releases

--- a/Makefile
+++ b/Makefile
@@ -72,7 +72,7 @@ darwin-shared: $(DARWIN_SHARED_LIB)
 
 $(DARWIN_SHARED_LIB):
 	mkdir -p $(DARWIN_DIR) && \
-	CC="o64-clang" CXX="o64-clang++" CGO_ENABLED=1 GOOS=darwin go build -buildmode=c-shared -o $(DARWIN_SHARED_LIB) $(NATIVE_LIB) && \
+	CGO_ENABLED=1 GOOS=darwin go build -buildmode=c-shared -o $(DARWIN_SHARED_LIB) $(NATIVE_LIB) && \
 	mv $(DARWIN_DIR)/$(HEADER_FILE) $(RESOURCES_DIR)/$(HEADER_FILE)
 
 $(LINUX_SHARED_LIB):


### PR DESCRIPTION
Fix enry-java on macOS Mojave

With the last version 1.6.7 on Mojave enry-java exists with Trace/BPT trap: 5
It happens only on _some_ files. I couldn't easily reproduce it without
spark. Rebuilding enry-java locally on my system solved the problem.
I assume cross-compiling using outdated libraries that don't work
anymore.

This PR uses travis osx enviroment to build shared library. It uses the
latest available osx_image.

Signed-off-by: Maxim Sukharev <max@smacker.ru>