### PR TITLE
Prevent tokenization from modifying its input.

### DIFF
--- a/internal/tokenizer/tokenize.go
+++ b/internal/tokenizer/tokenize.go
@@ -13,6 +13,10 @@ func Tokenize(content []byte) []string {
 		content = content[:byteLimit]
 	}
 
+	// Copy the input so that changes wrought by the tokenization steps do not
+	// modify the caller's copy of the input. See #196.
+	content = append([]byte(nil), content...)
+
 	tokens := make([][]byte, 0, 50)
 	for _, extract := range extractTokens {
 		var extractedTokens [][]byte

--- a/internal/tokenizer/tokenize_test.go
+++ b/internal/tokenizer/tokenize_test.go
@@ -102,7 +102,10 @@ func TestTokenize(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
+			before := string(test.content)
 			tokens := Tokenize(test.content)
+			after := string(test.content)
+			assert.Equal(t, before, after, "the input slice was modified")
 			assert.Equal(t, len(test.expected), len(tokens), fmt.Sprintf("token' slice length = %v, want %v", len(test.expected), len(tokens)))
 			for i, expectedToken := range test.expected {
 				assert.Equal(t, expectedToken, tokens[i], fmt.Sprintf("token = %v, want %v", tokens[i], expectedToken))


### PR DESCRIPTION
Fixes #196. Several steps of tokenization edit the input for the advantage of steps downstream.
However, these edits were on slices from the original input, so they changed the content seen
by the caller. Copy the input before slicing to avert that, and add a test to ensure it.

Signed-off-by: M. J. Fromberger <michael.j.fromberger@gmail.com>