### PR TITLE
Add documentation comments to package tokenizer.

### DIFF
--- a/internal/tokenizer/tokenize.go
+++ b/internal/tokenizer/tokenize.go
@@ -1,4 +1,4 @@
-// Package tokenizer implements file tokenization used by the enry file
+// Package tokenizer implements file tokenization used by the enry content
 // classifier. This package is an implementation detail of enry and should not
 // be imported by other packages.
 package tokenizer

--- a/internal/tokenizer/tokenize.go
+++ b/internal/tokenizer/tokenize.go
@@ -11,9 +11,9 @@ import (
 
 const byteLimit = 100000
 
-// Tokenize returns classification tokens from content. The tokens returned
-// should match what the Linguist library returns. At most the first 100KB of
-// content are tokenized.
+// Tokenize returns language-agnostic lexical tokens from content. The tokens
+// returned should match what the Linguist library returns. At most the first
+// 100KB of content are tokenized.
 func Tokenize(content []byte) []string {
 	if len(content) > byteLimit {
 		content = content[:byteLimit]

--- a/internal/tokenizer/tokenize.go
+++ b/internal/tokenizer/tokenize.go
@@ -1,3 +1,6 @@
+// Package tokenizer implements file tokenization used by the enry file
+// classifier. This package is an implementation detail of enry and should not
+// be imported by other packages.
 package tokenizer
 
 import (
@@ -8,6 +11,9 @@ import (
 
 const byteLimit = 100000
 
+// Tokenize returns classification tokens from content. The tokens returned
+// should match what the Linguist library returns. At most the first 100KB of
+// content are tokenized.
 func Tokenize(content []byte) []string {
 	if len(content) > byteLimit {
 		content = content[:byteLimit]


### PR DESCRIPTION
Although this package is internal, it still exports an API and deserves some
comments. Serves in partial satisfaction of #195.

Signed-off-by: M. J. Fromberger <michael.j.fromberger@gmail.com>