### PR TITLE
ci: add go 1.11 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,20 +2,24 @@ sudo: false
 dist: trusty
 
 language: go
-go:
-  - '1.10.x'
-
 go_import_path: gopkg.in/src-d/enry.v1
+
+go:
+  - '1.11.x'
+  - '1.10.x'
+env:
+  global:
+    - GO_VERSION_FOR_JVM='1.11.x'
+  matrix:
+    - ONIGURUMA=0
+    - ONIGURUMA=1
+matrix:
+  fast_finish: true
 
 addons:
   apt:
     packages:
       - libonig-dev
-
-env:
-  global:
-    - GO_VERSION='1.10.x'
-    - ONIGURUMA=0
 
 stages:
   - name: test
@@ -24,24 +28,17 @@ stages:
   - name: publish
     if: tag IS present
 
+stage: test
+install:
+  - if [[ -n "$ONIGURUMA" ]]; then tags="$tags oniguruma"; fi; go get -v -t --tags "$tags" ./...
+script:
+  - make test-coverage
+after_success:
+  - bash <(curl -s https://codecov.io/bash)
+
 jobs:
   include:
-    - &golang-unit-tests
-      name: 'golang unitTests'
-      stage: test
-      install:
-        - gimme version
-        - if [ "$ONIGURUMA" == "1" ]; then tags="$tags oniguruma"; fi; go get -v -t --tags "$tags" ./...
-      script:
-        - make test-coverage
-      after_success:
-        - bash <(curl -s https://codecov.io/bash)
-
-    - <<: *golang-unit-tests
-      name: 'golang unitTests, ONIGURUMA=1'
-      env: ONIGURUMA=1
-
-    - name: 'java unitTests'
+    - name: 'java unit-tests'
       stage: test
       language: scala
       jdk: oraclejdk8
@@ -53,8 +50,7 @@ jobs:
         - export TRAVIS_BUILD_DIR=${TRAVIS_HOME}/gopath/src/gopkg.in/src-d/enry.v1
         - cd ${TRAVIS_HOME}/gopath/src/gopkg.in/src-d/enry.v1
       install:
-        - gimme version
-        - eval "$(curl -sL https://raw.githubusercontent.com/travis-ci/gimme/master/gimme | GIMME_GO_VERSION=$GO_VERSION bash)"
+        - eval "$(curl -sL https://raw.githubusercontent.com/travis-ci/gimme/master/gimme | GIMME_GO_VERSION=$GO_VERSION_FOR_JVM bash)"
         - go version
         - echo $PWD; echo $GOPATH
         - go get -v ./...
@@ -67,6 +63,7 @@ jobs:
     - name: 'linux packages'
       stage: release
       install:
+        - go version
         - go get -v -t ./...
       script: make packages
       deploy:
@@ -82,6 +79,7 @@ jobs:
     - name: 'linux shared lib'
       stage: release
       install:
+        - go version
         - go get -v -t ./...
       script: make linux-shared
       deploy:
@@ -102,6 +100,7 @@ jobs:
         - OSXCROSS_URL="https://github.com/bblfsh/client-scala/releases/download/v1.5.2/${OSXCROSS_PACKAGE}"
         - PATH="/$HOME/osxcross/bin:$PATH"
       install:
+        - go version
         - go get -v -t ./...
         - sudo apt-get update
         - sudo apt-get install -y --no-install-recommends clang g++ gcc gcc-multilib libc6-dev libc6-dev-i386 mingw-w64 patch xz-utils
@@ -123,7 +122,7 @@ jobs:
       language: scala
       jdk: oraclejdk8
       install:
-        - eval "$(curl -sL https://raw.githubusercontent.com/travis-ci/gimme/master/gimme | GIMME_GO_VERSION=$GO_VERSION bash)"
+        - eval "$(curl -sL https://raw.githubusercontent.com/travis-ci/gimme/master/gimme | GIMME_GO_VERSION=$GO_VERSION_FOR_JVM bash)"
         - go version
         - go get -v gopkg.in/src-d/enry.v1/...
       before_script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -121,10 +121,17 @@ jobs:
       stage: publish
       language: scala
       jdk: oraclejdk8
+      before_install:
+        # mimics exact behavior of 'go_import_path' for non-go build image
+        - export GOPATH=${TRAVIS_HOME}/gopath
+        - mkdir -p ${GOPATH}/src/gopkg.in/src-d/enry.v1
+        - tar -Pczf ${TRAVIS_TMPDIR}/src_archive.tar.gz -C ${TRAVIS_BUILD_DIR} . && tar -Pxzf ${TRAVIS_TMPDIR}/src_archive.tar.gz -C ${TRAVIS_HOME}/gopath/src/gopkg.in/src-d/enry.v1
+        - export TRAVIS_BUILD_DIR=${TRAVIS_HOME}/gopath/src/gopkg.in/src-d/enry.v1
+        - cd ${TRAVIS_HOME}/gopath/src/gopkg.in/src-d/enry.v1
       install:
         - eval "$(curl -sL https://raw.githubusercontent.com/travis-ci/gimme/master/gimme | GIMME_GO_VERSION=$GO_VERSION_FOR_JVM bash)"
         - go version
-        - go get -v gopkg.in/src-d/enry.v1/...
+        - go get -v -t ./...
       before_script:
         - cd java
         - make

--- a/internal/code-generator/generator/generator_test.go
+++ b/internal/code-generator/generator/generator_test.go
@@ -2,7 +2,6 @@ package generator
 
 import (
 	"flag"
-	"fmt"
 	"io/ioutil"
 	"os"
 	"os/exec"
@@ -283,6 +282,6 @@ func (s *GeneratorTestSuite) TestGenerationFiles() {
 		assert.NoError(s.T(), err)
 		out, err := ioutil.ReadFile(outPath.Name())
 		assert.NoError(s.T(), err)
-		assert.EqualValues(s.T(), gold, out, fmt.Sprintf("%v: %v, expected: %v", test.name, string(out), string(gold)))
+		assert.Equal(s.T(), string(gold), string(out))
 	}
 }

--- a/internal/code-generator/generator/generator_test.go
+++ b/internal/code-generator/generator/generator_test.go
@@ -290,9 +290,9 @@ func (s *GeneratorTestSuite) TestGenerationFiles() {
 	}
 }
 
-// normalizeSpaces returns a copy of str with whitespaces normalizeds.
+// normalizeSpaces returns a copy of str with whitespaces normalized.
 // We use this to compare generated source as gofmt format may change.
-// E.g for changines beteween Go 1.10 and 1.11 see
+// E.g for changes between Go 1.10 and 1.11 see
 // https://go-review.googlesource.com/c/go/+/122295/
 func normalizeSpaces(str string) string {
 	return strings.Join(strings.Fields(str), " ")

--- a/internal/code-generator/generator/generator_test.go
+++ b/internal/code-generator/generator/generator_test.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -282,6 +283,17 @@ func (s *GeneratorTestSuite) TestGenerationFiles() {
 		assert.NoError(s.T(), err)
 		out, err := ioutil.ReadFile(outPath.Name())
 		assert.NoError(s.T(), err)
-		assert.Equal(s.T(), string(gold), string(out))
+
+		expected := normalizeSpaces(string(gold))
+		actual := normalizeSpaces(string(out))
+		assert.Equal(s.T(), expected, actual, "Test %s", test.name)
 	}
+}
+
+// normalizeSpaces returns a copy of str with whitespaces normalizeds.
+// We use this to compare generated source as gofmt format may change.
+// E.g for changines beteween Go 1.10 and 1.11 see
+// https://go-review.googlesource.com/c/go/+/122295/
+func normalizeSpaces(str string) string {
+	return strings.Join(strings.Fields(str), " ")
 }


### PR DESCRIPTION
Fixes part of the #191 

CI now tests Go test on both, 1.10 and 1.11

Generator tests rely on comparison to the golden gofmt'ed text blobs, but in [go 1.11 gofmt format changed](https://go-review.googlesource.com/c/go/+/122295/) 🤦‍♂️  This change does comparison in tests ignoring Unicode whitespaces (like a `git diff -w`)

`enry-java` is only released using go 1.11
