### PR TITLE
CLI app: sync accuracy of the report \w Linguist

### DIFF
--- a/README.md
+++ b/README.md
@@ -188,9 +188,18 @@ as a set for the tests, the following issues were found:
 
 * [Heuristics for ".es" extension](https://github.com/github/linguist/blob/e761f9b013e5b61161481fcb898b59721ee40e3d/lib/linguist/heuristics.yml#L103) in JavaScript could not be parsed, due to unsupported backreference in RE2 regexp engine
 
-* As of (Linguist v5.3.2)[https://github.com/github/linguist/releases/tag/v5.3.2] it is using [flex-based scanner in C for tokenization](https://github.com/github/linguist/pull/3846). Enry stil uses [extract_token](https://github.com/github/linguist/pull/3846/files#diff-d5179df0b71620e3fac4535cd1368d15L60) regex-based algorithm. Tracked under https://github.com/src-d/enry/issues/193
+* As of (Linguist v5.3.2)[https://github.com/github/linguist/releases/tag/v5.3.2] it is using [flex-based scanner in C for tokenization](https://github.com/github/linguist/pull/3846). Enry stil uses [extract_token](https://github.com/github/linguist/pull/3846/files#diff-d5179df0b71620e3fac4535cd1368d15L60) regex-based algorithm. [#193](https://github.com/src-d/enry/issues/193)
 
-* Bayesian classifier cann't distinguish "SQL" vs "PLpgSQL". Tracked under https://github.com/src-d/enry/issues/194
+* Bayesian classifier cann't distinguish "SQL" vs "PLpgSQL. [#194](https://github.com/src-d/enry/issues/194)
+
+* Dection of [generated files](https://github.com/github/linguist/blob/bf95666fc15e49d556f2def4d0a85338423c25f3/lib/linguist/generated.rb#L53) is not supported yet.
+ (Thus they are not exclued from CLI output) [#213](https://github.com/src-d/enry/issues/213)
+
+* XML detection strategy is not implemented. [#192](https://github.com/src-d/enry/issues/192)
+
+* Overriding languaes and types though `.gitattributes` is not yet supported. [#18](https://github.com/src-d/enry/issues/18)
+
+* enry CLI output does NOT exclude `.gitignore`ed files and submodel dirs as linguist does
 
 `enry` [CLI tool](#cli) does not require a full Git repository to be present in filesystem in order to report languages.
 

--- a/cmd/enry/main.go
+++ b/cmd/enry/main.go
@@ -85,6 +85,7 @@ func main() {
 
 		if enry.IsVendor(relativePath) || enry.IsDotFile(relativePath) ||
 			enry.IsDocumentation(relativePath) || enry.IsConfiguration(relativePath) {
+			//TODO(bzz): skip enry.IsGeneratedPath() after https://github.com/src-d/enry/issues/213
 			if f.IsDir() {
 				return filepath.SkipDir
 			}
@@ -105,13 +106,15 @@ func main() {
 			log.Println(err)
 			return nil
 		}
+		//TODO(bzz): skip enry.IsGeneratedContent() after https://github.com/src-d/enry/issues/213
 
 		language := enry.GetLanguage(filepath.Base(path), content)
 		if language == enry.OtherLanguage {
 			return nil
 		}
 
-		// If we are displaying only prog, skip it
+		// If we are not asked to display all, do as
+		// https://github.com/github/linguist/blob/bf95666fc15e49d556f2def4d0a85338423c25f3/lib/linguist/blob_helper.rb#L382
 		if !*allLangs &&
 			enry.GetLanguageType(language) != enry.Programming &&
 			enry.GetLanguageType(language) != enry.Markup {

--- a/common.go
+++ b/common.go
@@ -26,7 +26,7 @@ var DefaultStrategies = []Strategy{
 	GetLanguagesByClassifier,
 }
 
-// DefaultClassifier is a naive Bayes classifier based on Linguist samples.
+// DefaultClassifier is a Naive Bayes classifier trained on Linguist samples.
 var DefaultClassifier Classifier = &classifier{
 	languagesLogProbabilities: data.LanguagesLogProbabilities,
 	tokensLogProbabilities:    data.TokensLogProbabilities,
@@ -390,8 +390,8 @@ func getDotIndexes(filename string) []int {
 	return dots
 }
 
-// GetLanguagesByContent returns a slice of possible languages for the given content.
-// It complies with the signature to be a Strategy type.
+// GetLanguagesByContent returns a slice of languages for the given content.
+// It is a Strategy that uses a content-based regexp heuristics and a filename extension.
 func GetLanguagesByContent(filename string, content []byte, _ []string) []string {
 	if filename == "" {
 		return nil

--- a/internal/code-generator/generator/samplesfreq.go
+++ b/internal/code-generator/generator/samplesfreq.go
@@ -7,7 +7,6 @@ import (
 	"io/ioutil"
 	"log"
 	"math"
-	"os"
 	"path/filepath"
 	"sort"
 	"strconv"
@@ -41,7 +40,7 @@ func Frequencies(fileToParse, samplesDir, outPath, tmplPath, tmplName, commit st
 }
 
 func getFrequencies(samplesDir string) (*samplesFrequencies, error) {
-	entries, err := ioutil.ReadDir(samplesDir)
+	langDirs, err := ioutil.ReadDir(samplesDir)
 	if err != nil {
 		return nil, err
 	}
@@ -52,13 +51,14 @@ func getFrequencies(samplesDir string) (*samplesFrequencies, error) {
 	var tokens = make(map[string]map[string]int)
 	var languageTokens = make(map[string]int)
 
-	for _, entry := range entries {
-		if !entry.IsDir() {
+	for _, langDir := range langDirs {
+		if !langDir.IsDir() {
 			log.Println(err)
 			continue
 		}
 
-		samples, err := getSamples(samplesDir, entry)
+		lang := langDir.Name()
+		samples, err := getSamplesFrom(filepath.Join(samplesDir, lang))
 		if err != nil {
 			log.Println(err)
 		}
@@ -73,7 +73,6 @@ func getFrequencies(samplesDir string) (*samplesFrequencies, error) {
 			continue
 		}
 
-		lang := entry.Name()
 		languageTotal += len(samples)
 		languages[lang] = len(samples)
 		tokensTotal += len(samplesTokens)
@@ -93,22 +92,23 @@ func getFrequencies(samplesDir string) (*samplesFrequencies, error) {
 	}, nil
 }
 
-func getSamples(samplesDir string, langDir os.FileInfo) ([]string, error) {
-	const samplesSubDir = "filenames"
-	samples := []string{}
-	path := filepath.Join(samplesDir, langDir.Name())
-	entries, err := ioutil.ReadDir(path)
+func getSamplesFrom(samplesLangDir string) ([]string, error) {
+	const samplesLangFilesDir = "filenames"
+	var samples []string
+	sampleFiles, err := ioutil.ReadDir(samplesLangDir)
 	if err != nil {
 		return nil, err
 	}
 
-	for _, entry := range entries {
-		if entry.Mode().IsRegular() {
-			samples = append(samples, filepath.Join(path, entry.Name()))
+	for _, sampleFile := range sampleFiles {
+		filename := filepath.Join(samplesLangDir, sampleFile.Name())
+		if sampleFile.Mode().IsRegular() {
+			samples = append(samples, filename)
+			continue
 		}
 
-		if entry.IsDir() && entry.Name() == samplesSubDir {
-			subSamples, err := getSubSamples(samplesDir, langDir.Name(), entry)
+		if sampleFile.IsDir() && sampleFile.Name() == samplesLangFilesDir {
+			subSamples, err := getSubSamplesFrom(filename)
 			if err != nil {
 				return nil, err
 			}
@@ -121,9 +121,8 @@ func getSamples(samplesDir string, langDir os.FileInfo) ([]string, error) {
 	return samples, nil
 }
 
-func getSubSamples(samplesDir, langDir string, subLangDir os.FileInfo) ([]string, error) {
+func getSubSamplesFrom(path string) ([]string, error) {
 	subSamples := []string{}
-	path := filepath.Join(samplesDir, langDir, subLangDir.Name())
 	entries, err := ioutil.ReadDir(path)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
Fixes #204 by adjusting Enry CLI app behavior according to Linguist upstream.

 - [x] change defaults to show only programming and markup
 - [ ] change defaults to `-mode=bytes`