### PR TITLE
CI: workaround for incompatible compiler release binary 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,11 +5,11 @@ language: go
 go_import_path: gopkg.in/src-d/enry.v1
 
 go:
-  - '1.11.x'
-  - '1.10.x'
+  - '1.11.6'
+  - '1.12.1'
 env:
   global:
-    - GO_VERSION_FOR_JVM='1.11.x'
+    - GO_VERSION_FOR_JVM='1.11.'
   matrix:
     - ONIGURUMA=0
     - ONIGURUMA=1

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,8 @@ go:
   - '1.12.1'
 env:
   global:
-    - GO_VERSION_FOR_JVM='1.11.'
+    - GO_VERSION_FOR_JVM='1.11.1'
+    - CGO_ENABLED=0
   matrix:
     - ONIGURUMA=0
     - ONIGURUMA=1
@@ -30,7 +31,7 @@ stages:
 
 stage: test
 install:
-  - if [[ "${ONIGURUMA}" -gt 0 ]]; then export tags="${tags} oniguruma"; fi; go get -v -t -tags "${tags}" ./...
+  - if [[ "${ONIGURUMA}" -gt 0 ]]; then export tags="${tags} oniguruma"; CGO_ENABLED=1; fi; go get -v -t -tags "${tags}" ./...
 script:
   - make test-coverage
 after_success:
@@ -43,6 +44,7 @@ jobs:
       language: scala
       jdk: oraclejdk8
       before_install:
+        - CGO_ENABLED=1
         # mimics exact behavior of 'go_import_path' for non-go build image
         - export GOPATH=${TRAVIS_HOME}/gopath
         - mkdir -p ${GOPATH}/src/gopkg.in/src-d/enry.v1
@@ -122,6 +124,7 @@ jobs:
       language: scala
       jdk: oraclejdk8
       before_install:
+        - CGO_ENABLED=1
         # mimics exact behavior of 'go_import_path' for non-go build image
         - export GOPATH=${TRAVIS_HOME}/gopath
         - mkdir -p ${GOPATH}/src/gopkg.in/src-d/enry.v1

--- a/.travis.yml
+++ b/.travis.yml
@@ -30,7 +30,7 @@ stages:
 
 stage: test
 install:
-  - if [[ -n "$ONIGURUMA" ]]; then tags="$tags oniguruma"; fi; go get -v -t --tags "$tags" ./...
+  - if [[ "${ONIGURUMA}" -gt 0 ]]; then export tags="${tags} oniguruma"; fi; go get -v -t -tags "${tags}" ./...
 script:
   - make test-coverage
 after_success:

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ language: go
 go_import_path: gopkg.in/src-d/enry.v1
 
 go:
-  - '1.11.6'
+  - '1.11.6' # specific versions until https://github.com/golang/go/issues/31293
   - '1.12.1'
 env:
   global:
@@ -30,7 +30,12 @@ stages:
 
 stage: test
 install:
-  - if [[ "${ONIGURUMA}" -gt 0 ]]; then export tags="${tags} oniguruma"; CGO_ENABLED=1; fi; go get -v -t -tags "${tags}" ./...
+  - >
+    if [[ "${ONIGURUMA}" -gt 0 ]]; then
+      export tags="${tags} oniguruma";
+      export CGO_ENABLED=1;
+    fi;
+  - go get -v -t -tags "${tags}" ./...
 script:
   - make test-coverage
 after_success:
@@ -43,7 +48,7 @@ jobs:
       language: scala
       jdk: oraclejdk8
       before_install:
-        - CGO_ENABLED=1
+        - export CGO_ENABLED=1
         # mimics exact behavior of 'go_import_path' for non-go build image
         - export GOPATH=${TRAVIS_HOME}/gopath
         - mkdir -p ${GOPATH}/src/gopkg.in/src-d/enry.v1
@@ -123,7 +128,7 @@ jobs:
       language: scala
       jdk: oraclejdk8
       before_install:
-        - CGO_ENABLED=1
+        - export CGO_ENABLED=1
         # mimics exact behavior of 'go_import_path' for non-go build image
         - export GOPATH=${TRAVIS_HOME}/gopath
         - mkdir -p ${GOPATH}/src/gopkg.in/src-d/enry.v1

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,3 @@
-sudo: false
 dist: trusty
 
 language: go

--- a/internal/code-generator/generator/heuristics.go
+++ b/internal/code-generator/generator/heuristics.go
@@ -51,7 +51,7 @@ func loadHeuristics(yaml *Heuristics) (map[string][]*LanguagePattern, error) {
 		// unroll to a single map
 		for _, ext := range disambiguation.Extensions {
 			if _, ok := patterns[ext]; ok {
-				return nil, fmt.Errorf("cannt add extension '%s', it already exists for %q", ext, patterns[ext])
+				return nil, fmt.Errorf("cannt add extension '%s', it already exists for %+v", ext, patterns[ext])
 			}
 			patterns[ext] = rules
 		}

--- a/internal/code-generator/generator/heuristics.go
+++ b/internal/code-generator/generator/heuristics.go
@@ -51,7 +51,7 @@ func loadHeuristics(yaml *Heuristics) (map[string][]*LanguagePattern, error) {
 		// unroll to a single map
 		for _, ext := range disambiguation.Extensions {
 			if _, ok := patterns[ext]; ok {
-				return nil, fmt.Errorf("cannt add extension '%s', it already exists for %+v", ext, patterns[ext])
+				return nil, fmt.Errorf("cannot add extension '%s', it already exists for %+v", ext, patterns[ext])
 			}
 			patterns[ext] = rules
 		}


### PR DESCRIPTION
Instead of full distro update to get newer compiler https://github.com/src-d/enry/pull/221 - fix last known good go release versions on CI.

This will un-block the next, before-modules release.  

`.x` go version will be restored as soon as both new 1.11 and 1.12 are released https://github.com/src-d/enry/pull/221#issuecomment-481406314