### PR TITLE
Fix: import comment pointing to the latest module version

### DIFF
--- a/enry.go
+++ b/enry.go
@@ -11,6 +11,6 @@
 	Upstream Linguist YAML files are used to generate datastructures for data
 	package.
 */
-package enry // import "github.com/src-d/enry"
+package enry // import "github.com/src-d/enry/v2"
 
 //go:generate make code-generate


### PR DESCRIPTION
This important [import comment](https://golang.org/cmd/go/#hdr-Import_path_checking) was not updated on v2.0.0 release.

v2.0.1 should be release after merging this.