### PR TITLE
Match Nim color to its logo (the same as Github)

### DIFF
--- a/data/colors.go
+++ b/data/colors.go
@@ -140,7 +140,7 @@ var LanguagesColor = map[string]string{
 	"NetLogo":                  "#ff6375",
 	"NewLisp":                  "#87AED7",
 	"Nextflow":                 "#3ac486",
-	"Nim":                      "#37775b",
+	"Nim":                      "#ffc200",
 	"Nit":                      "#009917",
 	"Nix":                      "#7e7eff",
 	"Nu":                       "#c9df40",


### PR DESCRIPTION
Recently, Nim color on github was updated to match the color of the Nim logo to #ffc200

As many users use Gitea (and, therefore, enry), it would be nice to have matching colors for our beloved Nim if possible at all :)

Related: https://github.com/github/linguist/commit/9c8d6e7df8f50793d27d4adefadc3ec1c9945259